### PR TITLE
Fix compatibility issue between tt_address and newsletter subscribe

### DIFF
--- a/Classes/Domain/Model/Address.php
+++ b/Classes/Domain/Model/Address.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Undkonsorten\CuteMailingTtAddress\Domain\Model;
+
+
+/**
+ * Description of address
+ *
+ * 
+ */
+class Address extends \FriendsOfTYPO3\TtAddress\Domain\Model\Address{
+    
+    /**
+     * @var string
+    */
+    protected $subscriptionHash = '';
+
+    public function getSubscriptionHash(): string
+    {
+        return $this->subscriptionHash;
+    }
+
+    public function setSubscriptionHash($subscriptionHash): void
+    {
+        $this->subscriptionHash=$subscriptionHash;
+    }
+
+}

--- a/Classes/Domain/Model/RecipientInterface.php
+++ b/Classes/Domain/Model/RecipientInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Undkonsorten\CuteMailingTtAddress\Domain\Model;
+/**
+ * Description of RecipientInterface
+ *
+ * 
+ */
+interface RecipientInterface extends \Undkonsorten\CuteMailing\Domain\Model\RecipientInterface {
+    
+    
+    /**
+     * @return string
+     */
+    public function getSubscriptionHash(): string;
+
+
+    /**
+     * @param string $subscriptionHash
+     */
+    public function setSubscriptionHash(string $subscriptionHash): void;
+    
+    
+}

--- a/Classes/Domain/Model/SimpleRecipient.php
+++ b/Classes/Domain/Model/SimpleRecipient.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Undkonsorten\CuteMailingTtAddress\Domain\Model;
+/**
+ * Description of RecipientInterface
+ *
+ * 
+ */
+interface RecipientInterface extends \Undkonsorten\CuteMailing\Domain\Model\RecipientInterface {
+    
+    
+    /**
+     * @return string
+     */
+    public function getSubscriptionHash(): string;
+
+
+    /**
+     * @param string $subscriptionHash
+     */
+    public function setSubscriptionHash(string $subscriptionHash): void;
+    
+    
+}
+

--- a/Classes/Domain/Model/TtAddressRecipient.php
+++ b/Classes/Domain/Model/TtAddressRecipient.php
@@ -5,7 +5,7 @@ namespace Undkonsorten\CuteMailingTtAddress\Domain\Model;
 
 
 
-use FriendsOfTYPO3\TtAddress\Domain\Model\Address;
+use Undkonsorten\CuteMailingTtAddress\Domain\Model\Address;
 use Undkonsorten\CuteMailing\Domain\Model\RecipientInterface;
 
 class TtAddressRecipient extends Address implements RecipientInterface
@@ -14,5 +14,21 @@ class TtAddressRecipient extends Address implements RecipientInterface
     public function getUid(): int
     {
         return parent::getUid();
+    }
+    /**
+     * @return string
+     */
+    public function getSubscriptionHash(): string
+    {
+        return parent::getSubscriptionHash();
+    }
+
+                                             
+    /**
+     * @param string $subscriptionHash
+     */
+    public function setSubscriptionHash($subscriptionHash): void
+    {
+        parent::setSubscriptionHash($subscriptionHash);
     }
 }

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -8,7 +8,10 @@ use Undkonsorten\CuteMailingTtAddress\Domain\Model\TtAddressRecipientList;
 
 return [
 
-    \FriendsOfTYPO3\TtAddress\Domain\Model\Address::class => [
+    \Undkonsorten\CuteMailingTtAddress\Domain\Model\Address::class => [
+        'tableName' => 'tt_address',
+    ],
+    \Undkonsorten\CuteMailingTtAddress\Domain\Model\Address::class => [
         'subclasses' => [
             TtAddressRecipient::class => TtAddressRecipient::class,
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,6 +7,15 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 if (!defined('TYPO3')) {
     die('Access denied.');
 }
+// EXT:Address
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][FriendsOfTYPO3\TtAddress\Domain\Model\Address::class] = [
+    'className' => \Undkonsorten\CuteMailingTtAddress\Domain\Model\Address::class,
+];
+
+// EXT: cute_mailing
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][Undkonsorten\CuteMailing\Domain\Model\SimpleRecipient::class] = [
+    'className' => \Undkonsorten\CuteMailingTtAddress\Domain\Model\SimpleRecipient::class,
+];
 call_user_func(
     function ($extKey = 'cute_mailing_registeraddress') {
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['cuteMailing_ttAddressConvertWizard']


### PR DESCRIPTION



There was a compatibility conflict between the tt_address extension and the newsletter subscribe functionality.



Previously, the email handling caused issues when both systems interacted, especially regarding address handling and hashing.



To resolve this, I extended the tt_address handling so that:

the address data is properly expanded and processed

hash generation can now be used consistently

newsletter subscription works correctly together with tt_address



This ensures that both systems are now compatible and can be used together without conflicts.

please check it.